### PR TITLE
Updating the Aachen patch dockerfile to work with zstd compression

### DIFF
--- a/scripts/patch_aachen.Dockerfile
+++ b/scripts/patch_aachen.Dockerfile
@@ -22,8 +22,11 @@ RUN usermod --uid ${host_user_id} ${container_username}
 # a different user id to the user id for "user" in the container.
 RUN chmod 0755 /home/${container_username}/
 
+# get pacman-static from Eric Schwartz' repo to account for the new zstd compression
+RUN wget https://pkgbuild.com/~eschwartz/repo/x86_64-extracted/pacman-static && chmod +x pacman-static
+
 # Install tcmalloc so we can enforce a memory limit
-RUN pacman -Syy && pacman -S --noconfirm gperftools
+RUN ./pacman-static -Syy && ./pacman-static -S --noconfirm gperftools
 
 # Switch back to "user"
 USER ${container_username}


### PR DESCRIPTION
Fixes #6.  Updates the Dockerfile for the Aachen patch to use a `pacman` binary which supports Arch Linux's switch from xy compression to zstd.